### PR TITLE
Naive erlang

### DIFF
--- a/include/saturn_leaf.hrl
+++ b/include/saturn_leaf.hrl
@@ -27,6 +27,8 @@
 
 -define(HEARTBEAT_FREQ, 1000).
 
+-define(PROPAGATION_MODE, naive_erlang).
+
 -record(label, {operation :: remote_read | update | remote_reply,
                 bkey,
                 timestamp :: non_neg_integer(),

--- a/include/saturn_leaf.hrl
+++ b/include/saturn_leaf.hrl
@@ -28,6 +28,7 @@
 -define(HEARTBEAT_FREQ, 1000).
 
 -define(PROPAGATION_MODE, naive_erlang).
+%-define(PROPAGATION_MODE, short_tcp).
 
 -record(label, {operation :: remote_read | update | remote_reply,
                 bkey,

--- a/riak_test/five_nodes_test.erl
+++ b/riak_test/five_nodes_test.erl
@@ -50,6 +50,17 @@ confirm() ->
     Internal1 = hd(Cluster4),
     Internal2 = hd(Cluster5),
 
+    pong = rpc:call(Leaf1, net_adm, ping, [Leaf2]),
+    pong = rpc:call(Leaf1, net_adm, ping, [Leaf3]),
+    pong = rpc:call(Leaf1, net_adm, ping, [Internal1]),
+
+    pong = rpc:call(Leaf2, net_adm, ping, [Leaf3]),
+    pong = rpc:call(Leaf2, net_adm, ping, [Internal1]),
+
+    pong = rpc:call(Internal1, net_adm, ping, [Internal2]),
+
+    pong = rpc:call(Leaf3, net_adm, ping, [Internal2]),
+
     timer:sleep(1000),
     %% Starting leaf1
     {ok, HostPortLeaf1}=rpc:call(Leaf1, saturn_leaf_sup, start_leaf, [4040, 0]),

--- a/riak_test/remote_reads_test.erl
+++ b/riak_test/remote_reads_test.erl
@@ -49,6 +49,17 @@ confirm() ->
     Internal1 = hd(Cluster4),
     Internal2 = hd(Cluster5),
 
+    pong = rpc:call(Leaf1, net_adm, ping, [Leaf2]),
+    pong = rpc:call(Leaf1, net_adm, ping, [Leaf3]),
+    pong = rpc:call(Leaf1, net_adm, ping, [Internal1]),
+
+    pong = rpc:call(Leaf2, net_adm, ping, [Leaf3]),
+    pong = rpc:call(Leaf2, net_adm, ping, [Internal1]),
+
+    pong = rpc:call(Internal1, net_adm, ping, [Internal2]),
+
+    pong = rpc:call(Leaf3, net_adm, ping, [Internal2]),
+
     timer:sleep(1000),
     %% Starting leaf1
     {ok, HostPortLeaf1}=rpc:call(Leaf1, saturn_leaf_sup, start_leaf, [4040, 0]),

--- a/riak_test/two_leaf_one_internal_test.erl
+++ b/riak_test/two_leaf_one_internal_test.erl
@@ -45,6 +45,10 @@ confirm() ->
     Leaf2 = hd(Cluster2),
     Internal1 = hd(Cluster3),
 
+    pong = rpc:call(Leaf1, net_adm, ping, [Leaf2]),
+    pong = rpc:call(Leaf1, net_adm, ping, [Internal1]),
+    pong = rpc:call(Leaf2, net_adm, ping, [Internal1]),
+
     %% Starting leaf1
     {ok, HostPortLeaf1}=rpc:call(Leaf1, saturn_leaf_sup, start_leaf, [4040, 0]),
     %% Starting leaf2

--- a/riak_test/two_leaf_test.erl
+++ b/riak_test/two_leaf_test.erl
@@ -43,6 +43,8 @@ confirm() ->
     Node1 = hd(Cluster1),
     Node2 = hd(Cluster2),
 
+    pong = rpc:call(Node1, net_adm, ping, [Node2]),
+
     %% Starting servers in Node1
     {ok, HostPort0}=rpc:call(Node1, saturn_leaf_sup, start_leaf, [4040, 0]),
     

--- a/src/saturn_leaf_sup.erl
+++ b/src/saturn_leaf_sup.erl
@@ -48,15 +48,20 @@ start_leaf(Port, MyId) ->
     supervisor:start_child(?MODULE, {saturn_leaf_converger,
                     {saturn_leaf_converger, start_link, [MyId]},
                     permanent, 5000, worker, [saturn_leaf_converger]}),
-
-    supervisor:start_child(?MODULE, {saturn_leaf_tcp_recv_fsm,
+    
+    case ?PROPAGATION_MODE of
+        short_tcp ->
+            supervisor:start_child(?MODULE, {saturn_leaf_tcp_recv_fsm,
                     {saturn_leaf_tcp_recv_fsm, start_link, [Port, saturn_leaf_converger, MyId]},
                     permanent, 5000, worker, [saturn_leaf_tcp_recv_fsm]}),
 
-    supervisor:start_child(?MODULE, {saturn_leaf_tcp_connection_handler_fsm_sup,
+            supervisor:start_child(?MODULE, {saturn_leaf_tcp_connection_handler_fsm_sup,
                     {saturn_leaf_tcp_connection_handler_fsm_sup, start_link, []},
-                    permanent, 5000, supervisor, [saturn_leaf_tcp_connection_handler_fsm_sup]}),
+                    permanent, 5000, supervisor, [saturn_leaf_tcp_connection_handler_fsm_sup]});
 
+        _ ->
+            noop
+    end,
     supervisor:start_child(?MODULE, {saturn_leaf_producer,
                     {saturn_leaf_producer, start_link, [MyId]},
                     permanent, 5000, worker, [saturn_leaf_producer]}),

--- a/src/saturn_proxy_vnode.erl
+++ b/src/saturn_proxy_vnode.erl
@@ -168,10 +168,10 @@ handle_command({update, BKey, Value, Clock}, _From, S0=#state{max_ts=MaxTS0, par
     end,
     Label = create_label(update, BKey, TimeStamp, {Partition, node()}, MyId, {}),
     saturn_leaf_producer:new_label(MyId, Label, Partition),
-    case groups_manager_serv:get_datanodes(BKey) of
+    case groups_manager_serv:get_datanodes_ids(BKey) of
         {ok, Group} ->
-            lists:foreach(fun({Host, Port}) ->
-                            saturn_leaf_propagation_fsm_sup:start_fsm([Port, Host, {new_operation, Label, Value}])
+            lists:foreach(fun(Id) ->
+                            saturn_leaf_converger:handle(Id, {new_operation, Label, Value})
                           end, Group);
         {error, Reason2} ->
             lager:error("No replication group for bkey: ~p (~p)", [BKey, Reason2])


### PR DESCRIPTION
Adds naive erlang communication between tree nodes. It does it in a configurable manner without getting rid of the tcp-based communication used before.
